### PR TITLE
Feature/transfers an contact lis

### DIFF
--- a/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Confirmation/ConfirmationView.swift
+++ b/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Confirmation/ConfirmationView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class ConfirmationView: UIView, ConfigurableView {
 
-    //MARK: Elements Visual
+    //MARK: - Elements Visual
     private lazy var vStack: UIStackView = {
         let stack = UIStackView(frame: .zero)
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -53,12 +53,22 @@ final class ConfirmationView: UIView, ConfigurableView {
         return bt
     }()
     
-    //MARK: Inits
-    override init(frame: CGRect) {
+    // MARK: - Properties
+    var tapAction: Selector
+    var target: Any?
+    
+    
+    // MARK: - Inits
+    init(
+        selector: Selector,
+        target: Any?
+    ) {
+        self.tapAction = selector
+        self.target = target
         super.init(frame: .zero)
         backgroundColor = .white // backgroundColor View
         
-        setComponentsVisual()
+        setup()
     }
     
     //Obligatory
@@ -67,14 +77,14 @@ final class ConfirmationView: UIView, ConfigurableView {
     }
     
     //MARK: Init - Components
-    private func setComponentsVisual () {
+    private func setup () {
         initLayout()
+        addTargets()
     }
-
 }
 
 
-//MARK: Components and Constraints
+// MARK: - Components and Constraints
 extension ConfirmationView {
     func initSubviews() {
         addSubview(vStack)
@@ -101,4 +111,11 @@ extension ConfirmationView {
         ])
     }
     
+}
+
+// MARK: - Action Button
+extension ConfirmationView {
+    func addTargets() {
+        confirmationButton.addTarget(target, action: tapAction, for: .touchUpInside)
+    }
 }

--- a/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Confirmation/ConfirmationViewController.swift
+++ b/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Confirmation/ConfirmationViewController.swift
@@ -9,7 +9,17 @@ import UIKit
 
 class ConfirmationViewController: UIViewController {
 
+    private lazy var confirmationView: ConfirmationView = {
+        let confirmationView = ConfirmationView(selector: #selector(hanleNewTap), target: self)
+        
+        return confirmationView
+    }()
+    
     override func loadView() {
-        self.view = ConfirmationView()
+        self.view = confirmationView
+    }
+    
+    @objc func hanleNewTap() {
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Transfers/TransfersView.swift
+++ b/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Transfers/TransfersView.swift
@@ -7,7 +7,15 @@
 
 import UIKit
 
-class TransfersView: UIView {
+
+protocol TransfersViewDelegate: AnyObject {
+    func transfersConfimation()
+}
+
+final class TransfersView: UIView {
+    
+    // MARK: - Delegates
+    weak var delegate: TransfersViewDelegate?
     
     // MARK: - ViewCode Components
     private lazy var transfersStackView: UIStackView = {
@@ -80,33 +88,27 @@ class TransfersView: UIView {
         return button
     }()
     
+    
+    // MARK: - Initialization
     init() {
         super.init(frame: .zero)
         setup()
     }
-    
+
+
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
+        return nil
     }
 
+    
     // MARK: - Functions
     func setup() {
         setupLayout()
         addTargets()
     }
     
-    func addTargets() {
-        chooseContactButton.addTarget(self, action: #selector(didClickChooseContact), for: .touchUpInside)
-        transferButton.addTarget(self, action: #selector(didClickTransfer), for: .touchUpInside)
-        transferTextField.addTarget(self, action: #selector(didTransferTextFieldStartEditing(_:)), for: .allEditingEvents)
-    }
-    
-    @objc func didClickChooseContact() {}
-    
-    @objc func didClickTransfer() {}
-    
-    @objc func didTransferTextFieldStartEditing(_ sender: UITextField) {}
 }
+
 
 extension TransfersView {
     func setupLayout() {
@@ -154,3 +156,23 @@ extension TransfersView {
         ])
     }
 }
+
+
+// MARK: - Action Button
+extension TransfersView {
+    func addTargets() {
+        chooseContactButton.addTarget(self, action: #selector(didClickChooseContact), for: .touchUpInside)
+        transferButton.addTarget(self, action: #selector(didClickTransfer), for: .touchUpInside)
+        transferTextField.addTarget(self, action: #selector(didTransferTextFieldStartEditing(_:)), for: .allEditingEvents)
+    }
+    
+    @objc private func didClickChooseContact() {}
+    
+    @objc private func didClickTransfer() {
+        delegate?.transfersConfimation()
+    }
+    
+    @objc private func didTransferTextFieldStartEditing(_ sender: UITextField) {}
+}
+    
+

--- a/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Transfers/TransfersView.swift
+++ b/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Transfers/TransfersView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 
 protocol TransfersViewDelegate: AnyObject {
+    func ChooseContact()
     func transfersConfimation()
 }
 
@@ -166,7 +167,9 @@ extension TransfersView {
         transferTextField.addTarget(self, action: #selector(didTransferTextFieldStartEditing(_:)), for: .allEditingEvents)
     }
     
-    @objc private func didClickChooseContact() {}
+    @objc private func didClickChooseContact() {
+        delegate?.ChooseContact()
+    }
     
     @objc private func didClickTransfer() {
         delegate?.transfersConfimation()

--- a/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Transfers/TransfersViewController.swift
+++ b/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Transfers/TransfersViewController.swift
@@ -7,9 +7,28 @@
 
 import UIKit
 
-class TransfersViewController: UIViewController {
 
+final class TransfersViewController: UIViewController {
+    
+    private lazy var transferView: TransfersView = {
+        let transferView = TransfersView()
+        transferView.delegate = self
+        
+        return transferView
+    }()
+    
     override func loadView() {
-        self.view = TransfersView()
+        self.view = transferView
+    }
+    
+}
+
+// MARK: - Action Button
+extension TransfersViewController: TransfersViewDelegate {
+    func transfersConfimation() {
+        let confimationViewController = ConfirmationViewController()
+        
+        present(confimationViewController, animated: true)
     }
 }
+

--- a/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Transfers/TransfersViewController.swift
+++ b/solutions/devsprint-julio-fernandes-4/FinanceApp/Screens/Transfers/TransfersViewController.swift
@@ -25,6 +25,13 @@ final class TransfersViewController: UIViewController {
 
 // MARK: - Action Button
 extension TransfersViewController: TransfersViewDelegate {
+    func ChooseContact() {
+        let contactListViewController = ContactListViewController()
+        let rootContactListViewController = UINavigationController(rootViewController: contactListViewController)
+        
+        present(rootContactListViewController, animated: true)
+    }
+    
     func transfersConfimation() {
         let confimationViewController = ConfirmationViewController()
         


### PR DESCRIPTION
Ao tocar no botão de escolha de contato na tela Transfers, a aplicação deve navegar para a tela ContactList.

### Critérios de aceite

- [x]  Ao tocar no botão de escolha de contato na tela Transfers, a aplicação deve navegar para a tela ContactList
- [x]  A navegação deve ser do tipo "modal”